### PR TITLE
fix(deps): patcha vulnerabilità runtime (form-data, cookie, js-cookie) + fix expires e images.qualities

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,9 @@ module.exports = {
   },
   images: {
     unoptimized: true,
+    // Next 16 richiede di dichiarare esplicitamente i valori di `quality`
+    // usati nei componenti <Image> (default: solo 75). article-card usa 90.
+    qualities: [75, 90],
     remotePatterns: [
       {protocol: 'https', hostname: 'be.matarrese.it'},
       {protocol: 'https', hostname: 'www.matarrese.it'},

--- a/package.json
+++ b/package.json
@@ -50,8 +50,9 @@
   "pnpm": {
     "overrides": {
       "axios": "^1.18.1",
-      "form-data": "^4.0.4",
-      "tar-fs": "^3.0.9"
+      "form-data": "^4.0.6",
+      "tar-fs": "^3.0.9",
+      "cookie": "^0.7.2"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "plaiceholder": "^2.3.0",
     "prop-types": "^15.8.1",
     "react": "18.3.1",
-    "react-cookie-consent": "^7.4.1",
+    "react-cookie-consent": "^10.0.1",
     "react-dom": "18.3.1",
     "react-image-lightbox": "^5.1.4",
     "react-lottie-player": "^2.1.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -111,7 +111,7 @@ function MyApp({Component, pageProps}) {
             color: '#fff',
             // fontSize: '16px',
           }}
-          expires={getCookieConsentValue == false ? 1 : 365}
+          expires={365}
         >
           Questo sito web utilizza alcuni cookie per poter miglorare
           l&apos;esperinza dell&apos;utente.{' '}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1
       react-cookie-consent:
-        specifier: ^7.4.1
-        version: 7.6.0(react@18.3.1)
+        specifier: ^10.0.1
+        version: 10.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -1940,8 +1940,8 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
-  js-cookie@2.2.1:
-    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2392,10 +2392,12 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  react-cookie-consent@7.6.0:
-    resolution: {integrity: sha512-FGPZWCMXRQ+1Km+IOg+6+CyBA1OlS5NQ8svbI1B/iQlyon/ZbREGzkPamQmf9PHU+ULBY9Gik9DDhLUtdawMMQ==}
+  react-cookie-consent@10.0.1:
+    resolution: {integrity: sha512-qgU7Kr+x9/feKZxaIJbMT+R/xD1lnAQy9MzD4yLooVrkhoUR7XFc8Xv8M+GDQYcjoYh6uszslLGo1k+eU2VLtw==}
+    engines: {node: '>=20.16'}
     peerDependencies:
-      react: ^16.13.1 || ^17.0.0 || ^18.0.0
+      react: '>=18'
+      react-dom: '>=18'
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -4798,7 +4800,7 @@ snapshots:
 
   jiti@1.21.7: {}
 
-  js-cookie@2.2.1: {}
+  js-cookie@3.0.8: {}
 
   js-tokens@4.0.0: {}
 
@@ -5231,11 +5233,11 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  react-cookie-consent@7.6.0(react@18.3.1):
+  react-cookie-consent@10.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      js-cookie: 2.2.1
-      prop-types: 15.8.1
+      js-cookie: 3.0.8
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,9 @@ settings:
 
 overrides:
   axios: ^1.18.1
-  form-data: ^4.0.4
+  form-data: ^4.0.6
   tar-fs: ^3.0.9
+  cookie: ^0.7.2
 
 importers:
 
@@ -1273,8 +1274,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@0.5.0:
-    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   cosmiconfig@7.1.0:
@@ -1624,8 +1625,8 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fraction.js@5.3.4:
@@ -1737,6 +1738,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hermes-estree@0.25.1:
@@ -3843,7 +3848,7 @@ snapshots:
   axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -3981,7 +3986,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@0.5.0: {}
+  cookie@0.7.2: {}
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -4173,7 +4178,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
@@ -4467,12 +4472,12 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fraction.js@5.3.4: {}
@@ -4590,6 +4595,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -4645,7 +4654,7 @@ snapshots:
       '@types/express': 4.17.25
       '@types/koa': 2.15.0
       '@types/node': 17.0.45
-      cookie: 0.5.0
+      cookie: 0.7.2
       iron-webcrypto: 0.2.8
     optionalDependencies:
       next: 16.2.10(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Cosa

Chiude le vulnerabilità **runtime** segnalate da `pnpm audit` (quelle che finiscono nel bundle server/browser di produzione) e sistema due piccoli difetti emersi durante la verifica.

### Sicurezza (runtime)
- **`form-data`** `^4.0.4` → `^4.0.6` (override pnpm). L'override precedente risolveva `4.0.5`, ancora vulnerabile alla CRLF injection (patch: `>=4.0.6`). Arriva via `axios`.
- **`cookie`** `^0.7.2` (nuovo override pnpm). Fix out-of-bounds chars; arriva via `iron-session` (cookie di sessione).
- **`react-cookie-consent`** `7.6.0` → `10.0.1`, che usa `js-cookie ^3.0.5` → risolve `3.0.8` (patch del prototype hijack, era pinnato a `2.2.1`). Peer `react >=18` soddisfatto.

### Fix collaterali
- **`_app.js`**: `expires` del `CookieConsent` era `getCookieConsentValue == false ? 1 : 365` — confronto tra il **riferimento della funzione** e `false`, sempre falso → sempre `365`. Codice morto rimosso: `expires={365}` (comportamento invariato).
- **`next.config.js`**: aggiunto `images.qualities: [75, 90]` per silenziare il warning di Next 16 su `quality={90}` in `article-card.jsx`. Nessuna modifica a `unoptimized` né all'output.

## Perché

Bump ereditato dal lavoro su Next 16 / ESLint 9: dopo l'audit, le uniche vulnerabilità con reale superficie d'attacco (runtime) sono state chiuse. Le rimanenti sono tutte dev/build-tooling (ReDoS/DoS in ESLint/build, input fidato) e sono state **lasciate volutamente** fuori scope.

**Risultato audit: 17 → 14 vulnerabilità** (tutte e 3 le runtime target chiuse; le 14 residue sono dev-tooling).

## Note per il reviewer

- L'override di `cookie` (`0.7.2`) esce dal range dichiarato da `iron-session` (`^0.5.0`) ma l'API `parse`/`serialize` è compatibile. **Verificato a runtime**: `/api/user` (`withSessionRoute`) risponde `200 {"isLoggedIn":false}` senza errori.
- `react-cookie-consent` 7→10 è un salto di 3 major su un componente **GDPR-critico** (banner che sblocca GTM/FB Pixel). Le props usate sono API core stabili tra le versioni. **Verificato a runtime**: banner renderizzato con "Declino"/"Accetto tutti i cookies" e link a `/cookie-policy`; click su "Accetto" scrive `CookieConsent=true` via js-cookie 3.0.8 e nasconde il banner; nessun errore console.
- `pnpm lint` verde; home e `/news` rendono `200` senza il warning `qualities`.
- **Non incluso** (dev-tooling, scelta esplicita): `minimatch`, `flatted`, `picomatch`, `brace-expansion`, `js-yaml`, `postcss`, `yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)